### PR TITLE
struct to json fix

### DIFF
--- a/template.go
+++ b/template.go
@@ -21,7 +21,7 @@ type Template struct {
 	Display                    *Display           `json:"display,omitempty"`
 	HighAvailability           *HighAvailability  `json:"high_availability,omitempty"`
 	LargeIcon                  *Link              `json:"large_icon,omitempty"`
-	Memory                     int                `json:"memory,omitempty"`
+	Memory                     int                `json:"memory,string,omitempty"`
 	MemoryPolicy               *MemoryPolicy      `json:"memory_policy,omitempty"`
 	Migration                  *MigrationOptions  `json:"migration,omitempty"`
 	MigrationDowntime          string             `json:"migration_downtime,omitempty"`

--- a/vm.go
+++ b/vm.go
@@ -314,8 +314,8 @@ type MemoryOverCommit struct {
 // MemoryPolicy Logical grouping of memory related properties of virtual machine-like entities.
 type MemoryPolicy struct {
 	Ballooning           string                `json:"ballooning,omitempty"`
-	Guaranteed           int                   `json:"guaranteed,omitempty"`
-	Max                  int                   `json:"max,omitempty"`
+	Guaranteed           int                   `json:"guaranteed,string,omitempty"`
+	Max                  int                   `json:"max,string,omitempty"`
 	OverCommit           *MemoryOverCommit     `json:"over_commit,omitempty"`
 	TransparentHugePages *TransparentHugePages `json:"transparent_huge_pages,omitempty"`
 }
@@ -410,7 +410,7 @@ type VM struct {
 	Initialization             *Initialization       `json:"initialization,omitempty"`
 	Io                         *IO                   `json:"io,omitempty"`
 	LargeIcon                  *Link                 `json:"large_icon,omitempty"`
-	Memory                     int                   `json:"memory,omitempty"`
+	Memory                     int                   `json:"memory,string,omitempty"`
 	MemoryPolicy               *MemoryPolicy         `json:"memory_policy,omitempty"`
 	Migration                  *MigrationOptions     `json:"migration,omitempty"`
 	MigrationDowntime          int                   `json:"migration_downtime,omitempty,string"`


### PR DESCRIPTION
using terraform-provider-ovirt on oVirt 4.2 cluster I observed errors in plan apply due to json conversion.
I tracked down the problem to be in go sources of ovirtapi, which is used by terraform-provider-ovirt.
I modified a few structs in ovirtapi and the problem is now solved.
This pull request is to merge the changes into the original project.